### PR TITLE
Feature/bugfix

### DIFF
--- a/LobotJR.Shared/Authentication/AuthToken.cs
+++ b/LobotJR.Shared/Authentication/AuthToken.cs
@@ -1,7 +1,6 @@
 ﻿using LobotJR.Shared.Utility;
 using NLog;
 using RestSharp;
-using RestSharp.Serializers.NewtonsoftJson;
 using System;
 using System.Net;
 using System.Threading.Tasks;
@@ -25,17 +24,15 @@ namespace LobotJR.Shared.Authentication
         /// <returns>The API response containing an OAuth token.</returns>
         public static async Task<TokenResponse> Fetch(string clientId, string clientSecret, string code, string redirectUri)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            var client = new RestClient("https://id.twitch.tv");
-            client.UseNewtonsoftJson(SerializerSettings.Default);
+            var client = RestUtils.CreateStandardClient();
             var request = new RestRequest("oauth2/token", Method.Post);
+            RestLogger.AddLogging(request, Logger, true);
             request.AddHeader("Accept", "application/json");
             request.AddQueryParameter("client_id", clientId);
             request.AddQueryParameter("client_secret", clientSecret);
             request.AddQueryParameter("code", code);
             request.AddQueryParameter("grant_type", "authorization_code");
             request.AddQueryParameter("redirect_uri", redirectUri);
-            RestLogger.AddLogging(request, Logger, true);
             var response = await client.ExecuteAsync<TokenResponse>(request);
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -52,13 +49,11 @@ namespace LobotJR.Shared.Authentication
         /// <returns>The validation response.</returns>
         public static async Task<ValidationResponse> Validate(string token)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            var client = new RestClient("https://id.twitch.tv");
-            client.UseNewtonsoftJson(SerializerSettings.Default);
+            var client = RestUtils.CreateStandardClient();
             var request = new RestRequest("oauth2/validate", Method.Get);
+            RestLogger.AddLogging(request, Logger, true);
             request.AddHeader("Accept", "application/json");
             request.AddHeader("Authorization", $"Bearer {token}");
-            RestLogger.AddLogging(request, Logger, true);
             var response = await client.ExecuteAsync<ValidationResponse>(request);
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -76,17 +71,15 @@ namespace LobotJR.Shared.Authentication
         /// <returns>The API containing a new OAuth token.</returns>
         public static async Task<RestResponse<TokenResponse>> Refresh(string clientId, string clientSecret, string refreshToken)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            var client = new RestClient("https://id.twitch.tv");
-            client.UseNewtonsoftJson(SerializerSettings.Default);
+            var client = RestUtils.CreateStandardClient();
             var request = new RestRequest("oauth2/token", Method.Post);
+            RestLogger.AddLogging(request, Logger, true);
             request.AddHeader("Accept", "application/json");
             request.AddHeader("Content-Type", "application/x-www-form-urlencoded");
             request.AddParameter("grant_type", "refresh_token");
             request.AddParameter("refresh_token", refreshToken);
             request.AddParameter("client_id", clientId);
             request.AddParameter("client_secret", clientSecret);
-            RestLogger.AddLogging(request, Logger, true);
             var response = await client.ExecuteAsync<TokenResponse>(request);
             if (response.StatusCode == HttpStatusCode.OK)
             {

--- a/LobotJR.Shared/Channel/Moderators.cs
+++ b/LobotJR.Shared/Channel/Moderators.cs
@@ -1,9 +1,9 @@
-﻿using LobotJR.Shared.Utility;
+﻿using LobotJR.Shared.Authentication;
+using LobotJR.Shared.Client;
+using LobotJR.Shared.Utility;
 using NLog;
 using RestSharp;
-using RestSharp.Serializers.NewtonsoftJson;
 using System.Collections.Generic;
-using System.Net;
 using System.Threading.Tasks;
 
 namespace LobotJR.Shared.Channel
@@ -21,47 +21,41 @@ namespace LobotJR.Shared.Channel
         /// moderators of a channel. Retrieves the first 100 users starting
         /// from the specified value.
         /// </summary>
-        /// <param name="token">The OAuth token for the user making the call.
+        /// <param name="token">The OAuth token object for the user making the call.
         /// The token id must match the broadcaster id.</param>
-        /// <param name="clientId">The client id of the application.</param>
+        /// <param name="clientData">The client data for the app executing the request.</param>
         /// <param name="broadcasterId">The id of the channel to get moderators for.</param>
         /// <param name="start">The pagination cursor value to start from. If
         /// this is the first request, set to null.</param>
         /// <returns>The response body from the API, or null if the response code is not 200 (OK).</returns>
-        public static async Task<RestResponse<ChannelUserResponse>> Get(string token, string clientId, string broadcasterId, string start = null)
+        public static async Task<RestResponse<ChannelUserResponse>> Get(TokenResponse token, ClientData clientData, string broadcasterId, string start = null)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            var client = new RestClient("https://api.twitch.tv");
-            client.UseNewtonsoftJson(SerializerSettings.Default);
-            var request = new RestRequest("helix/moderation/moderators", Method.Get);
-            request.AddHeader("Accept", "application/json");
-            request.AddHeader("Authorization", $"Bearer {token}");
-            request.AddHeader("Client-ID", clientId);
+            var client = RestUtils.CreateStandardClient();
+            var request = RestUtils.CreateStandardRequest("helix/moderation/moderators", Method.Get, token.AccessToken, clientData.ClientId, Logger);
             request.AddParameter("broadcaster_id", broadcasterId, ParameterType.QueryString);
             if (start != null)
             {
                 request.AddParameter("after", start, ParameterType.QueryString);
             }
             request.AddParameter("first", 100, ParameterType.QueryString);
-            RestLogger.AddLogging(request, Logger);
-            return await client.ExecuteAsync<ChannelUserResponse>(request);
+            return await RestUtils.ExecuteWithRefresh<ChannelUserResponse>(token, clientData, client, request);
         }
 
         /// <summary>
         /// Gets all moderators for a given channel.
         /// </summary>
-        /// <param name="token">The OAuth token for the user making the call.
+        /// <param name="token">The OAuth token object for the user making the call.
         /// The token id must match the broadcaster id.</param>
-        /// <param name="clientId">The client id of the application.</param>
+        /// <param name="clientData">The client data for the app executing the request.</param>
         /// <param name="broadcasterId">The id of the channel to get moderators for.</param>
         /// <returns>A list of rest responses containing pages of all moderators for the channel.</returns>
-        public static async Task<IEnumerable<RestResponse<ChannelUserResponse>>> GetAll(string token, string clientId, string broadcasterId)
+        public static async Task<IEnumerable<RestResponse<ChannelUserResponse>>> GetAll(TokenResponse token, ClientData clientData, string broadcasterId)
         {
             List<RestResponse<ChannelUserResponse>> data = new List<RestResponse<ChannelUserResponse>>();
             string cursor = null;
             do
             {
-                var response = await Get(token, clientId, broadcasterId, cursor);
+                var response = await Get(token, clientData, broadcasterId, cursor);
                 data.Add(response);
                 cursor = response.Data?.Pagination?.Cursor;
             }

--- a/LobotJR.Shared/Channel/Subscriptions.cs
+++ b/LobotJR.Shared/Channel/Subscriptions.cs
@@ -1,9 +1,9 @@
-﻿using LobotJR.Shared.Utility;
+﻿using LobotJR.Shared.Authentication;
+using LobotJR.Shared.Client;
+using LobotJR.Shared.Utility;
 using NLog;
 using RestSharp;
-using RestSharp.Serializers.NewtonsoftJson;
 using System.Collections.Generic;
-using System.Net;
 using System.Threading.Tasks;
 
 namespace LobotJR.Shared.Channel
@@ -21,47 +21,41 @@ namespace LobotJR.Shared.Channel
         /// of all subscribers to a channel. Retrieves the first 100 users
         /// starting from the specified value.
         /// </summary>
-        /// <param name="token">The OAuth token for the user making the call.
+        /// <param name="token">The OAuth token object for the user making the call.
         /// The token id must match the broadcaster id.</param>
-        /// <param name="clientId">The client id of the application.</param>
+        /// <param name="clientData">The client data for the app executing the request.</param>
         /// <param name="broadcasterId">The id of the channel to get subscribers for.</param>
         /// <param name="start">The pagination cursor value to start from. If
         /// this is the first request, set to null.</param>
         /// <returns>The response body from the API, or null if the response code is not 200 (OK).</returns>
-        public static async Task<RestResponse<SubscriptionResponse>> Get(string token, string clientId, string broadcasterId, string start = null)
+        public static async Task<RestResponse<SubscriptionResponse>> Get(TokenResponse token, ClientData clientData, string broadcasterId, string start = null)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            var client = new RestClient("https://api.twitch.tv");
-            client.UseNewtonsoftJson(SerializerSettings.Default);
-            var request = new RestRequest("helix/subscriptions", Method.Get);
-            request.AddHeader("Accept", "application/json");
-            request.AddHeader("Authorization", $"Bearer {token}");
-            request.AddHeader("Client-ID", clientId);
+            var client = RestUtils.CreateStandardClient();
+            var request = RestUtils.CreateStandardRequest("helix/subscriptions", Method.Get, token.AccessToken, clientData.ClientId, Logger);
             request.AddParameter("broadcaster_id", broadcasterId, ParameterType.QueryString);
             if (start != null)
             {
                 request.AddParameter("after", start, ParameterType.QueryString);
             }
             request.AddParameter("first", 100, ParameterType.QueryString);
-            RestLogger.AddLogging(request, Logger);
-            return await client.ExecuteAsync<SubscriptionResponse>(request);
+            return await RestUtils.ExecuteWithRefresh<SubscriptionResponse>(token, clientData, client, request);
         }
 
         /// <summary>
         /// Gets all users subscribed to a given channel.
         /// </summary>
-        /// <param name="token">The OAuth token for the user making the call.
+        /// <param name="token">The OAuth token object for the user making the call.
         /// The token id must match the broadcaster id.</param>
-        /// <param name="clientId">The client id of the application.</param>
+        /// <param name="clientData">The client data for the app executing the request.</param>
         /// <param name="broadcasterId">The id of the channel to ban the user from.</param>
         /// <returns>A list of rest responses containing pages of all subscribers for the channel.</returns>
-        public static async Task<IEnumerable<RestResponse<SubscriptionResponse>>> GetAll(string token, string clientId, string broadcasterId)
+        public static async Task<IEnumerable<RestResponse<SubscriptionResponse>>> GetAll(TokenResponse token, ClientData clientData, string broadcasterId)
         {
             List<RestResponse<SubscriptionResponse>> data = new List<RestResponse<SubscriptionResponse>>();
             string cursor = null;
             do
             {
-                var response = await Get(token, clientId, broadcasterId, cursor);
+                var response = await Get(token, clientData, broadcasterId, cursor);
                 data.Add(response);
                 cursor = response.Data?.Pagination?.Cursor;
             }

--- a/LobotJR.Shared/Channel/VIPs.cs
+++ b/LobotJR.Shared/Channel/VIPs.cs
@@ -1,9 +1,9 @@
-﻿using LobotJR.Shared.Utility;
+﻿using LobotJR.Shared.Authentication;
+using LobotJR.Shared.Client;
+using LobotJR.Shared.Utility;
 using NLog;
 using RestSharp;
-using RestSharp.Serializers.NewtonsoftJson;
 using System.Collections.Generic;
-using System.Net;
 using System.Threading.Tasks;
 
 namespace LobotJR.Shared.Channel
@@ -21,47 +21,41 @@ namespace LobotJR.Shared.Channel
         /// a channel. Retrieves the first 100 users starting from the
         /// specified value.
         /// </summary>
-        /// <param name="token">The OAuth token for the user making the call.
+        /// <param name="token">The OAuth token object for the user making the call.
         /// The token id must match the broadcaster id.</param>
-        /// <param name="clientId">The client id of the application.</param>
+        /// <param name="clientData">The client data for the app executing the request.</param>
         /// <param name="broadcasterId">The id of the channel to get VIPs for.</param>
         /// <param name="start">The pagination cursor value to start from. If
         /// this is the first request, set to null.</param>
         /// <returns>The response body from the API, or null if the response code is not 200 (OK).</returns>
-        public static async Task<RestResponse<ChannelUserResponse>> Get(string token, string clientId, string broadcasterId, string start = null)
+        public static async Task<RestResponse<ChannelUserResponse>> Get(TokenResponse token, ClientData clientData, string broadcasterId, string start = null)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            var client = new RestClient("https://api.twitch.tv");
-            client.UseNewtonsoftJson(SerializerSettings.Default);
-            var request = new RestRequest("helix/channels/vips", Method.Get);
-            request.AddHeader("Accept", "application/json");
-            request.AddHeader("Authorization", $"Bearer {token}");
-            request.AddHeader("Client-ID", clientId);
+            var client = RestUtils.CreateStandardClient();
+            var request = RestUtils.CreateStandardRequest("helix/channels/vips", Method.Get, token.AccessToken, clientData.ClientId, Logger);
             request.AddParameter("broadcaster_id", broadcasterId, ParameterType.QueryString);
             if (start != null)
             {
                 request.AddParameter("after", start, ParameterType.QueryString);
             }
             request.AddParameter("first", 100, ParameterType.QueryString);
-            RestLogger.AddLogging(request, Logger);
-            return await client.ExecuteAsync<ChannelUserResponse>(request);
+            return await RestUtils.ExecuteWithRefresh<ChannelUserResponse>(token, clientData, client, request);
         }
 
         /// <summary>
         /// Gets all VIPs for a given channel.
         /// </summary>
-        /// <param name="token">The OAuth token for the user making the call.
+        /// <param name="token">The OAuth token object for the user making the call.
         /// The token id must match the broadcaster id.</param>
-        /// <param name="clientId">The client id of the application.</param>
+        /// <param name="clientData">The client data for the app executing the request.</param>
         /// <param name="broadcasterId">The id of the channel to get VIPs for.</param>
         /// <returns>A list of rest responses containing pages of all VIPs for the channel.</returns>
-        public static async Task<IEnumerable<RestResponse<ChannelUserResponse>>> GetAll(string token, string clientId, string broadcasterId)
+        public static async Task<IEnumerable<RestResponse<ChannelUserResponse>>> GetAll(TokenResponse token, ClientData clientData, string broadcasterId)
         {
             List<RestResponse<ChannelUserResponse>> data = new List<RestResponse<ChannelUserResponse>>();
             string cursor = null;
             do
             {
-                var response = await Get(token, clientId, broadcasterId, cursor);
+                var response = await Get(token, clientData, broadcasterId, cursor);
                 data.Add(response);
                 cursor = response.Data?.Pagination?.Cursor;
             }

--- a/LobotJR.Shared/Chat/Whisper.cs
+++ b/LobotJR.Shared/Chat/Whisper.cs
@@ -1,8 +1,8 @@
-﻿using LobotJR.Shared.Utility;
+﻿using LobotJR.Shared.Authentication;
+using LobotJR.Shared.Client;
+using LobotJR.Shared.Utility;
 using NLog;
 using RestSharp;
-using RestSharp.Serializers.NewtonsoftJson;
-using System.Net;
 using System.Threading.Tasks;
 
 namespace LobotJR.Shared.Chat
@@ -18,43 +18,21 @@ namespace LobotJR.Shared.Chat
         /// <summary>
         /// Calls the twitch Send Whisper API to whisper a message to a user.
         /// </summary>
-        /// <param name="token">The OAuth token for the user making the call.
-        /// The token id must match the sender id.</param>
-        /// <param name="clientId">The client id of the application.</param>
+        /// <param name="token">The OAuth token object for the user making the
+        /// call. The token id must match the sender id.</param>
+        /// <param name="clientData">The client data for the app executing the request.</param>
         /// <param name="senderId">The id of the user sending the message.</param>
         /// <param name="userId">The id of the user to send the whisper to.</param>
-        /// <returns>The http response code from the API.</returns>
-        public static async Task<HttpStatusCode> Post(string token, string clientId, string senderId, string userId, string message)
+        /// <returns>The rest response object for the API call.</returns>
+        public static async Task<RestResponse> Post(TokenResponse token, ClientData clientData, string senderId, string userId, string message)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            var client = new RestClient("https://api.twitch.tv");
-            client.UseNewtonsoftJson(SerializerSettings.Default);
-            var request = new RestRequest("helix/whispers", Method.Post);
-            request.AddHeader("Accept", "application/json");
-            request.AddHeader("Authorization", $"Bearer {token}");
-            request.AddHeader("Client-ID", clientId);
+            var client = RestUtils.CreateStandardClient();
+            var request = RestUtils.CreateStandardRequest("helix/whispers", Method.Post, token.AccessToken, clientData.ClientId, Logger);
             request.AddParameter("from_user_id", senderId, ParameterType.QueryString);
             request.AddParameter("to_user_id", userId, ParameterType.QueryString);
             request.AddBody(new WhisperRequest(message));
-            RestLogger.AddLogging(request, Logger);
             var response = await client.ExecuteAsync(request);
-            return response.StatusCode;
-        }
-    }
-
-    /// <summary>
-    /// The request object used to send a whisper.
-    /// </summary>
-    public class WhisperRequest
-    {
-        /// <summary>
-        /// The content of the whisper to send.
-        /// </summary>
-        public string Message { get; set; }
-
-        public WhisperRequest(string message)
-        {
-            Message = message;
+            return await RestUtils.ExecuteWithRefresh(token, clientData, client, request);
         }
     }
 }

--- a/LobotJR.Shared/Chat/Whisper.cs
+++ b/LobotJR.Shared/Chat/Whisper.cs
@@ -31,7 +31,6 @@ namespace LobotJR.Shared.Chat
             request.AddParameter("from_user_id", senderId, ParameterType.QueryString);
             request.AddParameter("to_user_id", userId, ParameterType.QueryString);
             request.AddBody(new WhisperRequest(message));
-            var response = await client.ExecuteAsync(request);
             return await RestUtils.ExecuteWithRefresh(token, clientData, client, request);
         }
     }

--- a/LobotJR.Shared/Chat/WhisperRequest.cs
+++ b/LobotJR.Shared/Chat/WhisperRequest.cs
@@ -1,0 +1,19 @@
+﻿namespace LobotJR.Shared.Chat
+{
+
+    /// <summary>
+    /// The request object used to send a whisper.
+    /// </summary>
+    public class WhisperRequest
+    {
+        /// <summary>
+        /// The content of the whisper to send.
+        /// </summary>
+        public string Message { get; set; }
+
+        public WhisperRequest(string message)
+        {
+            Message = message;
+        }
+    }
+}

--- a/LobotJR.Shared/LobotJR.Shared.csproj
+++ b/LobotJR.Shared/LobotJR.Shared.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Chat\ChattersResponse.cs" />
     <Compile Include="Chat\Chatters.cs" />
     <Compile Include="Chat\Whisper.cs" />
+    <Compile Include="Chat\WhisperRequest.cs" />
     <Compile Include="Client\ClientData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Channel\SubscriptionResponse.cs" />
@@ -112,6 +113,7 @@
     <Compile Include="Utility\FileUtils.cs" />
     <Compile Include="Utility\NewtonsoftDeserializer.cs" />
     <Compile Include="Utility\Pagination.cs" />
+    <Compile Include="Utility\RestUtils.cs" />
     <Compile Include="Utility\RestLogger.cs" />
     <Compile Include="Utility\SerializerSettings.cs" />
   </ItemGroup>

--- a/LobotJR.Shared/User/BanUser.cs
+++ b/LobotJR.Shared/User/BanUser.cs
@@ -1,7 +1,8 @@
-﻿using LobotJR.Shared.Utility;
+﻿using LobotJR.Shared.Authentication;
+using LobotJR.Shared.Client;
+using LobotJR.Shared.Utility;
 using NLog;
 using RestSharp;
-using RestSharp.Serializers.NewtonsoftJson;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -18,29 +19,23 @@ namespace LobotJR.Shared.User
         /// <summary>
         /// Calls the twitch Ban User API to ban a user for a set duration.
         /// </summary>
-        /// <param name="token">The OAuth token for the user making the call.
-        /// The token id must match the moderator id.</param>
-        /// <param name="clientId">The client id of the application.</param>
+        /// <param name="token">The OAuth token object to use for authentication.
+        /// The id of the access token must match the moderator id.</param>
+        /// <param name="clientData">The client data for the app executing the request.</param>
         /// <param name="broadcasterId">The id of the channel to ban the user from.</param>
         /// <param name="moderatorId">The id of the user executing the ban (must be a moderator of the channel).</param>
         /// <param name="userId">The id of the user to ban.</param>
         /// <param name="duration">The duration of the ban. Set this to null for a permanent ban.</param>
         /// <param name="reason">An optional string with the reason for the ban.</param>
         /// <returns>The http response code from the API.</returns>
-        public static async Task<HttpStatusCode> Post(string token, string clientId, string broadcasterId, string moderatorId, string userId, int? duration, string reason)
+        public static async Task<HttpStatusCode> Post(TokenResponse token, ClientData clientData, string broadcasterId, string moderatorId, string userId, int? duration, string reason)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            var client = new RestClient("https://api.twitch.tv");
-            client.UseNewtonsoftJson(SerializerSettings.Default);
-            var request = new RestRequest("helix/moderation/bans", Method.Post);
-            request.AddHeader("Accept", "application/json");
-            request.AddHeader("Authorization", $"Bearer {token}");
-            request.AddHeader("Client-ID", clientId);
+            var client = RestUtils.CreateStandardClient();
+            var request = RestUtils.CreateStandardRequest("helix/moderation/bans", Method.Post, token.AccessToken, clientData.ClientId, Logger);
             request.AddParameter("broadcaster_id", broadcasterId, ParameterType.QueryString);
             request.AddParameter("moderator_id", moderatorId, ParameterType.QueryString);
             request.AddJsonBody(new BanRequest(userId, duration, reason));
-            RestLogger.AddLogging(request, Logger);
-            var response = await client.ExecuteAsync(request);
+            var response = await RestUtils.ExecuteWithRefresh(token, clientData, client, request);
             return response.StatusCode;
         }
     }

--- a/LobotJR.Shared/Utility/RestUtils.cs
+++ b/LobotJR.Shared/Utility/RestUtils.cs
@@ -1,0 +1,112 @@
+﻿using LobotJR.Shared.Authentication;
+using LobotJR.Shared.Client;
+using NLog;
+using RestSharp;
+using RestSharp.Serializers.NewtonsoftJson;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace LobotJR.Shared.Utility
+{
+    public class RestUtils
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        /// <summary>
+        /// Executes a rest request. If the response indicates the access token
+        /// has expired, a refresh is attempted. If the refresh is successful,
+        /// the request is executed again and the response is returned. If the
+        /// refresh fails, the original request failure is returned.
+        /// </summary>
+        /// <typeparam name="T">The expected response type.</typeparam>
+        /// <param name="tokenResponse">The token data used in the request.</param>
+        /// <param name="clientData">The client information used in the request.</param>
+        /// <param name="client">The rest client to use when executing the request.</param>
+        /// <param name="request">The request object to execute against the client.</param>
+        /// <returns>The response of the rest request. The response content
+        /// will be deserialized into type T.</returns>
+        public static async Task<RestResponse<T>> ExecuteWithRefresh<T>(TokenResponse tokenResponse, ClientData clientData, RestClient client, RestRequest request) where T : class
+        {
+            var response = await client.ExecuteAsync<T>(request);
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                Logger.Warn($"Unauthorized response calling Twitch API. Refreshing token.");
+                var authResponse = await AuthToken.Refresh(clientData.ClientId, clientData.ClientSecret, tokenResponse.RefreshToken);
+                if (authResponse == null || authResponse.StatusCode != HttpStatusCode.OK)
+                {
+                    Logger.Error("Token refresh failed. Something may be wrong with the access token, please delete token.json and relaunch the application.");
+                    return response;
+                }
+                tokenResponse.CopyFrom(authResponse.Data);
+                request.AddOrUpdateHeader("Authorization", $"Bearer {tokenResponse.AccessToken}");
+                response = await client.ExecuteAsync<T>(request);
+            }
+            return response;
+        }
+
+        /// <summary>
+        /// Executes a rest request. If the response indicates the access token
+        /// has expired, a refresh is attempted. If the refresh is successful,
+        /// the request is executed again and the response is returned. If the
+        /// refresh fails, the original request failure is returned.
+        /// </summary>
+        /// <typeparam name="T">The expected response type.</typeparam>
+        /// <param name="tokenResponse">The token data used in the request.</param>
+        /// <param name="clientData">The client information used in the request.</param>
+        /// <param name="client">The rest client to use when executing the request.</param>
+        /// <param name="request">The request object to execute against the client.</param>
+        /// <returns>The response of the rest request. The response content
+        /// will not be deserialized. Use this if no response body is expected.</returns>
+        public static async Task<RestResponse> ExecuteWithRefresh(TokenResponse tokenResponse, ClientData clientData, RestClient client, RestRequest request)
+        {
+            var response = await client.ExecuteAsync(request);
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                Logger.Warn($"Unauthorized response calling Twitch API. Refreshing token.");
+                var authResponse = await AuthToken.Refresh(clientData.ClientId, clientData.ClientSecret, tokenResponse.RefreshToken);
+                if (authResponse == null || authResponse.StatusCode != HttpStatusCode.OK)
+                {
+                    Logger.Error("Token refresh failed. Something may be wrong with the access token, please delete token.json and relaunch the application.");
+                    return response;
+                }
+                tokenResponse.CopyFrom(authResponse.Data);
+                request.AddOrUpdateHeader("Authorization", $"Bearer {tokenResponse.AccessToken}");
+                response = await client.ExecuteAsync(request);
+            }
+            return response;
+        }
+
+        /// <summary>
+        /// Creates a standard rest client for use when making rest requests to
+        /// the Twitch API.
+        /// </summary>
+        /// <returns>A rest client configured for the Twitch API.</returns>
+        public static RestClient CreateStandardClient()
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+            var client = new RestClient("https://api.twitch.tv");
+            client.UseNewtonsoftJson(SerializerSettings.Default);
+            return client;
+        }
+
+        /// <summary>
+        /// Creates a standard rest request for use when making requests to the
+        /// Twitch API.
+        /// </summary>
+        /// <param name="endpoint">The url endpoint to call.</param>
+        /// <param name="method">The method of the request.</param>
+        /// <param name="token">An OAuth token to authenticate the request.</param>
+        /// <param name="clientId">The client id of the app making the call.</param>
+        /// <param name="logger">An NLog instance to write log data to.</param>
+        /// <returns>A rest request configured for the Twitch API.</returns>
+        public static RestRequest CreateStandardRequest(string endpoint, Method method, string token, string clientId, Logger logger)
+        {
+            var request = new RestRequest(endpoint, method);
+            RestLogger.AddLogging(request, logger);
+            request.AddHeader("Accept", "application/json");
+            request.AddHeader("Authorization", $"Bearer {token}");
+            request.AddHeader("Client-ID", clientId);
+            return request;
+        }
+    }
+}

--- a/LobotJR/Command/CommandManager.cs
+++ b/LobotJR/Command/CommandManager.cs
@@ -3,6 +3,7 @@ using LobotJR.Command.Module;
 using LobotJR.Command.Module.AccessControl;
 using LobotJR.Data;
 using LobotJR.Data.User;
+using NLog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,6 +16,8 @@ namespace LobotJR.Command
     /// </summary>
     public class CommandManager : ICommandManager
     {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         public static readonly char Prefix = '!';
 
         private const int MessageLimit = 450;
@@ -265,6 +268,7 @@ namespace LobotJR.Command
         /// <returns>Whether a command was found and executed.</returns>
         public CommandResult ProcessMessage(string message, string user, bool isWhisper)
         {
+            Logger.Debug("Attempting to process {user}'s command: {message}", user, message);
             var request = CommandRequest.Parse(message);
             if (commandStringToIdMap.TryGetValue(request.CommandString, out var commandId))
             {

--- a/LobotJR/Command/Module/Fishing/LeaderboardModule.cs
+++ b/LobotJR/Command/Module/Fishing/LeaderboardModule.cs
@@ -91,7 +91,7 @@ namespace LobotJR.Command.Module.Fishing
                     {
                         $"You've caught {items.Count} different types of fish: "
                     };
-                    responses.AddRange(items.Select((x, i) => $"{i}: {x.Fish.Name}"));
+                    responses.AddRange(items.Select((x, i) => $"{i + 1}: {x.Fish.Name}"));
                     return new CommandResult(responses.ToArray());
                 }
                 else

--- a/LobotJR/Command/Module/Fishing/LeaderboardModule.cs
+++ b/LobotJR/Command/Module/Fishing/LeaderboardModule.cs
@@ -63,7 +63,7 @@ namespace LobotJR.Command.Module.Fishing
                 {
                     return new CompactCollection<Catch>(records, selectFunc);
                 }
-                return new CompactCollection<Catch>(new Catch[0], null);
+                return new CompactCollection<Catch>(new Catch[0], selectFunc);
             }
             else
             {

--- a/LobotJR/Command/System/Fishing/FishingSystem.cs
+++ b/LobotJR/Command/System/Fishing/FishingSystem.cs
@@ -1,6 +1,7 @@
 ﻿using LobotJR.Command.Model.Fishing;
 using LobotJR.Data;
 using LobotJR.Utils;
+using NLog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,6 +13,8 @@ namespace LobotJR.Command.System.Fishing
     /// </summary>
     public class FishingSystem : ISystem
     {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         private readonly Random Random = new Random();
         private readonly int[] Chances = new int[] { 40, 70, 95, 99, 100 };
 
@@ -203,6 +206,7 @@ namespace LobotJR.Command.System.Fishing
                 var fishList = FishData.Read(x => x.Rarity.Id == rarityId).ToList();
                 var fish = fishList[Random.Next(0, fishList.Count)];
                 fisher.Hooked = fish;
+                Logger.Debug("Fish {fish} hooked for user {userId}.", fish?.Name, fisher.UserId);
                 return true;
             }
             return false;
@@ -234,6 +238,7 @@ namespace LobotJR.Command.System.Fishing
                 fisher.IsFishing = false;
                 fisher.Hooked = null;
                 fisher.HookedTime = null;
+                Logger.Debug("User id {userId} catching fish {fish}", fisher.UserId, catchData?.Fish?.Name);
                 if (catchData != null)
                 {
                     OnFishCaught(fisher, catchData);
@@ -255,6 +260,7 @@ namespace LobotJR.Command.System.Fishing
                     && fisher.Hooked == null
                     && DateTime.Now >= fisher.HookedTime)
                 {
+                    Logger.Debug("Hooking fish for user {userId}.", fisher.UserId);
                     if (HookFish(fisher))
                     {
                         OnFishHooked(fisher);
@@ -265,6 +271,7 @@ namespace LobotJR.Command.System.Fishing
                     && fisher.HookedTime.HasValue
                     && DateTime.Now >= fisher.HookedTime.Value.AddSeconds(Settings.FishingHookLength))
                 {
+                    Logger.Debug("Fish got away for user {userId}.", fisher.UserId);
                     UnhookFish(fisher);
                     OnFishGotAway(fisher);
                 }

--- a/LobotJR/Command/System/Fishing/LeaderboardSystem.cs
+++ b/LobotJR/Command/System/Fishing/LeaderboardSystem.cs
@@ -1,5 +1,6 @@
 ﻿using LobotJR.Command.Model.Fishing;
 using LobotJR.Data;
+using NLog;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -10,6 +11,8 @@ namespace LobotJR.Command.System.Fishing
     /// </summary>
     public class LeaderboardSystem : ISystem
     {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         private readonly IRepository<LeaderboardEntry> Leaderboard;
         private readonly IRepository<Catch> PersonalLeaderboard;
 
@@ -79,6 +82,7 @@ namespace LobotJR.Command.System.Fishing
             var record = PersonalLeaderboard.Read(x => x.UserId.Equals(userId) && x.Fish.Equals(catchData.Fish)).FirstOrDefault();
             if (record == null || record.Weight < catchData.Weight)
             {
+                Logger.Debug("Catch set a new personal record for user {userId}, fish {fish} at {weight} pounds.", userId, catchData.Fish?.Name, catchData.Weight);
                 if (record == null)
                 {
                     PersonalLeaderboard.Create(catchData);
@@ -107,6 +111,7 @@ namespace LobotJR.Command.System.Fishing
                 if (index >= 0 && records.Count() > index)
                 {
                     var record = records.ElementAt(index);
+                    Logger.Debug("Removed fish {fish} at index {index} for user id {userId}", record?.Fish?.Name, index, userId);
                     PersonalLeaderboard.Delete(record);
                     PersonalLeaderboard.Commit();
                 }
@@ -137,6 +142,7 @@ namespace LobotJR.Command.System.Fishing
             var record = Leaderboard.Read(x => x.Fish.Equals(catchData.Fish)).FirstOrDefault();
             if (record == null || record.Weight < catchData.Weight)
             {
+                Logger.Debug("Catch set a new global record for fish {fish} at {weight} pounds.", catchData.Fish?.Name, catchData.Weight);
                 if (record == null)
                 {
                     Leaderboard.Create(entry);

--- a/LobotJR/Data/AppSettings.cs
+++ b/LobotJR/Data/AppSettings.cs
@@ -68,5 +68,13 @@
         /// The name of the logging file to write output data to.
         /// </summary>
         public string LoggingFile { get; set; } = "output.log";
+        /// <summary>
+        /// The max size of the logging file in megabytes.
+        /// </summary>
+        public int LoggingMaxSize { get; set; } = 8;
+        /// <summary>
+        /// The number of archived logging files and crash dumps to keep.
+        /// </summary>
+        public int LoggingMaxArchives { get; set; } = 8;
     }
 }

--- a/LobotJR/Data/Import/FisherDataImport.cs
+++ b/LobotJR/Data/Import/FisherDataImport.cs
@@ -1,5 +1,7 @@
 ﻿using LobotJR.Command.Model.Fishing;
 using LobotJR.Data.User;
+using LobotJR.Shared.Authentication;
+using LobotJR.Shared.Client;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -67,15 +69,15 @@ namespace LobotJR.Data.Import
         /// </summary>
         /// <param name="usernames">A collection of twitch usernames.</param>
         /// <param name="userLookup">The user lookup system to convert usernames into user ids.</param>
-        /// <param name="token">The OAuth token for making twitch API calls.</param>
-        /// <param name="clientId">The client id used to identify the call to fetch the user ids.</param>
-        public static void FetchUserIds(IEnumerable<string> usernames, UserLookup userLookup, string token, string clientId)
+        /// <param name="token">The OAuth token object for making twitch API calls.</param>
+        /// <param name="clientData">The client data for the app executing the request.</param>
+        public static void FetchUserIds(IEnumerable<string> usernames, UserLookup userLookup, TokenResponse token, ClientData clientData)
         {
             foreach (var fisher in usernames)
             {
                 userLookup.GetId(fisher);
             }
-            userLookup.UpdateCache(token, clientId).GetAwaiter().GetResult();
+            userLookup.UpdateCache(token, clientData).GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/LobotJR/Data/Migration/DatabaseUpdate-1.0.3-1.0.4.cs
+++ b/LobotJR/Data/Migration/DatabaseUpdate-1.0.3-1.0.4.cs
@@ -1,0 +1,39 @@
+﻿using NuGet.Versioning;
+using System;
+using System.Data.Entity;
+
+namespace LobotJR.Data.Migration
+{
+    public class DatabaseUpdate_1_0_3_1_0_4 : IDatabaseUpdate
+    {
+        public SemanticVersion FromVersion => new SemanticVersion(1, 0, 3);
+        public SemanticVersion ToVersion => new SemanticVersion(1, 0, 4);
+        public bool UsesMetadata => true;
+
+
+        public DatabaseMigrationResult Update(DbContext context)
+        {
+            var result = new DatabaseMigrationResult { Success = true };
+            var commands = new string[]
+            {
+                "ALTER TABLE \"AppSettings\" ADD COLUMN [LoggingMaxSize] int",
+                "ALTER TABLE \"AppSettings\" ADD COLUMN [LoggingMaxArchives] int",
+                "UPDATE \"AppSettings\" SET [LoggingMaxSize] = 8, [LoggingMaxArchives] = 8"
+            };
+            result.DebugOutput.Add("Executing SQL statements to add/update tables...");
+            foreach (var command in commands)
+            {
+                result.DebugOutput.Add(command);
+                try
+                {
+                    context.Database.ExecuteSqlCommand(command);
+                }
+                catch (Exception e)
+                {
+                    result.DebugOutput.Add($"Exception: {e}");
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/LobotJR/Data/Migration/DatabaseUpdate-Null-1.0.0.cs
+++ b/LobotJR/Data/Migration/DatabaseUpdate-Null-1.0.0.cs
@@ -73,7 +73,7 @@ namespace LobotJR.Data.Migration
             {
                 if (id != null && !string.IsNullOrWhiteSpace(id.Id))
                 {
-                    idMap.Add(id.DisplayName, id.Id);
+                    idMap.Add(id.Login, id.Id);
                 }
             }
 

--- a/LobotJR/Data/Migration/DatabaseUpdate-Null-1.0.0.cs
+++ b/LobotJR/Data/Migration/DatabaseUpdate-Null-1.0.0.cs
@@ -11,8 +11,8 @@ namespace LobotJR.Data.Migration
 {
     public class DatabaseUpdate_Null_1_0_0 : IDatabaseUpdate
     {
-        private readonly string Token;
-        private readonly string ClientId;
+        private readonly TokenData TokenData;
+        private readonly ClientData ClientData;
 
         public SemanticVersion FromVersion => null;
         public SemanticVersion ToVersion => new SemanticVersion(1, 0, 0);
@@ -21,8 +21,8 @@ namespace LobotJR.Data.Migration
 
         public DatabaseUpdate_Null_1_0_0(TokenData token, ClientData client)
         {
-            Token = token.BroadcastToken.AccessToken;
-            ClientId = client.ClientId;
+            TokenData = token;
+            ClientData = client;
         }
 
         public DatabaseMigrationResult Update(DbContext context)
@@ -63,9 +63,13 @@ namespace LobotJR.Data.Migration
             var roleNames = roleNameLists.SelectMany(x => x.Split(','));
             var allNames = new List<string>(tournamentNames);
             allNames.AddRange(roleNames);
-            var ids = Users.Get(Token, ClientId, allNames.Distinct()).GetAwaiter().GetResult();
+            var ids = Users.Get(TokenData.BroadcastToken, ClientData, allNames.Distinct()).GetAwaiter().GetResult();
+            if (ids == null || ids.Data == null)
+            {
+                return new DatabaseMigrationResult { Success = false };
+            }
             var idMap = new Dictionary<string, string>();
-            foreach (var id in ids.Data)
+            foreach (var id in ids.Data.Data)
             {
                 if (id != null && !string.IsNullOrWhiteSpace(id.Id))
                 {

--- a/LobotJR/Data/Migration/SqliteDatabaseUpdater.cs
+++ b/LobotJR/Data/Migration/SqliteDatabaseUpdater.cs
@@ -13,7 +13,7 @@ namespace LobotJR.Data.Migration
     /// </summary>
     public class SqliteDatabaseUpdater
     {
-        public static readonly SemanticVersion LatestVersion = new SemanticVersion(1, 0, 3);
+        public static readonly SemanticVersion LatestVersion = new SemanticVersion(1, 0, 4);
 
         private readonly IEnumerable<IDatabaseUpdate> DatabaseUpdates;
 

--- a/LobotJR/Data/User/UserLookup.cs
+++ b/LobotJR/Data/User/UserLookup.cs
@@ -86,21 +86,21 @@ namespace LobotJR.Data.User
                     Logger.Warn("Null response attempting to fetch user ids while updating user cache.");
                     return results;
                 }
-                results.UpdatedUsers.AddRange(response.Data.Data.Where(x => x != null).Select(x => x.DisplayName));
+                results.UpdatedUsers.AddRange(response.Data.Data.Where(x => x != null).Select(x => x.Login));
                 results.FailedUsers.AddRange(removed.Except(results.UpdatedUsers));
                 foreach (var entry in response.Data.Data)
                 {
                     var existing = UserMap.Read(x => x.TwitchId.Equals(entry.Id)).FirstOrDefault();
                     if (existing != null)
                     {
-                        existing.Username = entry.DisplayName;
+                        existing.Username = entry.Login;
                         UserMap.Update(existing);
                     }
                     else
                     {
                         UserMap.Create(new UserMap()
                         {
-                            Username = entry.DisplayName,
+                            Username = entry.Login,
                             TwitchId = entry.Id
                         });
                     }

--- a/LobotJR/LobotJR.csproj
+++ b/LobotJR/LobotJR.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Data\Import\FileSystem.cs" />
     <Compile Include="Data\Import\IFileSystem.cs" />
     <Compile Include="Data\Metadata.cs" />
+    <Compile Include="Data\Migration\DatabaseUpdate-1.0.3-1.0.4.cs" />
     <Compile Include="Data\Migration\DatabaseUpdate-1.0.2-1.0.3.cs" />
     <Compile Include="Data\Migration\DatabaseUpdate-1.0.1-1.0.2.cs" />
     <Compile Include="Data\Migration\DatabaseUpdate-Null-1.0.0.cs" />

--- a/LobotJR/LobotJR.csproj
+++ b/LobotJR/LobotJR.csproj
@@ -18,7 +18,7 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.7.0</ApplicationVersion>
+    <ApplicationVersion>1.0.8.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>

--- a/LobotJR/Program.cs
+++ b/LobotJR/Program.cs
@@ -500,7 +500,7 @@ namespace TwitchBot
                         Dictionary<string, LegacyFisher> legacyFisherData = FisherDataImport.LoadLegacyFisherData(FisherDataImport.FisherDataPath);
                         List<LegacyCatch> legacyLeaderboardData = FisherDataImport.LoadLegacyFishingLeaderboardData(FisherDataImport.FishingLeaderboardPath);
                         Logger.Info("Converting usernames to user ids...");
-                        FisherDataImport.FetchUserIds(legacyFisherData.Keys.Union(legacyLeaderboardData.Select(x => x.caughtBy)), userLookup, tokenData.BroadcastToken.AccessToken, clientData.ClientId);
+                        FisherDataImport.FetchUserIds(legacyFisherData.Keys.Union(legacyLeaderboardData.Select(x => x.caughtBy)), userLookup, tokenData.BroadcastToken, clientData);
                         if (hasFisherData)
                         {
                             Logger.Info("Importing user records...");
@@ -559,7 +559,7 @@ namespace TwitchBot
                         if (userLookup.IsUpdateTime(DateTime.Now))
                         {
                             cacheUpdate = true;
-                            var cacheUpdateResults = userLookup.UpdateCache(tokenData.BroadcastToken.AccessToken, clientData.ClientId).GetAwaiter().GetResult();
+                            var cacheUpdateResults = userLookup.UpdateCache(tokenData.BroadcastToken, clientData).GetAwaiter().GetResult();
                             foreach (var user in cacheUpdateResults.UpdatedUsers)
                             {
                                 twitchClient.QueueWhisper(user, "All done! Whisper me \"!cast\" to fish!");
@@ -3761,7 +3761,10 @@ namespace TwitchBot
                                     case "!xpon":
                                         {
                                             wolfcoins.UpdateViewers(twitchClient).GetAwaiter().GetResult();
-                                            if (wolfcoins.moderatorList.Contains(sender) || sender == tokenData.BroadcastUser || sender == tokenData.ChatUser || sender == "lan5432")
+                                            if (wolfcoins.moderatorList.Contains(sender, StringComparer.OrdinalIgnoreCase)
+                                                || sender.Equals(tokenData.BroadcastUser, StringComparison.OrdinalIgnoreCase)
+                                                || sender.Equals(tokenData.ChatUser, StringComparison.OrdinalIgnoreCase)
+                                                || sender.Equals("lan5432", StringComparison.OrdinalIgnoreCase))
                                             {
                                                 if (!broadcasting)
                                                 {
@@ -3784,7 +3787,10 @@ namespace TwitchBot
                                     case "!xpoff":
                                         {
                                             wolfcoins.UpdateViewers(twitchClient).GetAwaiter().GetResult();
-                                            if (wolfcoins.moderatorList.Contains(sender) || sender == tokenData.BroadcastUser || sender == tokenData.ChatUser || sender == "lan5432")
+                                            if (wolfcoins.moderatorList.Contains(sender, StringComparer.OrdinalIgnoreCase)
+                                                || sender.Equals(tokenData.BroadcastUser, StringComparison.OrdinalIgnoreCase)
+                                                || sender.Equals(tokenData.ChatUser, StringComparison.OrdinalIgnoreCase)
+                                                || sender.Equals("lan5432", StringComparison.OrdinalIgnoreCase))
                                             {
                                                 if (broadcasting)
                                                 {

--- a/LobotJR/Twitch/WhisperQueue.cs
+++ b/LobotJR/Twitch/WhisperQueue.cs
@@ -15,7 +15,7 @@ namespace LobotJR.Twitch
         /// <summary>
         /// The name of the user to send the whisper to.
         /// </summary>
-        public string Username { get; set; }
+        public string Username { get; private set; }
         /// <summary>
         /// The Twitch id of the user.
         /// </summary>
@@ -23,11 +23,11 @@ namespace LobotJR.Twitch
         /// <summary>
         /// The content of the whisper.
         /// </summary>
-        public string Message { get; set; }
+        public string Message { get; private set; }
         /// <summary>
         /// The time the message was queued.
         /// </summary>
-        public DateTime QueueTime { get; set; }
+        public DateTime QueueTime { get; private set; }
 
         public WhisperRecord(string userName, string userId, string message, DateTime queueTime)
         {
@@ -35,6 +35,28 @@ namespace LobotJR.Twitch
             UserId = userId;
             Message = message;
             QueueTime = queueTime;
+        }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as WhisperRecord;
+            return other != null
+                && (string.Equals(Username, other.Username, StringComparison.OrdinalIgnoreCase))
+                && (string.Equals(Message, other.Message, StringComparison.OrdinalIgnoreCase))
+                && QueueTime.Equals(other.QueueTime);
+        }
+
+        private int GetStringHash(string str)
+        {
+            return str == null ? 0 : str.GetHashCode();
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = GetStringHash(Username) * 17;
+            hash = (hash + GetStringHash(Message)) * 17;
+            hash = (hash + QueueTime.GetHashCode()) * 17;
+            return hash;
         }
     }
 

--- a/LobotJR/Utils/AutofacSetup.cs
+++ b/LobotJR/Utils/AutofacSetup.cs
@@ -32,6 +32,7 @@ namespace LobotJR.Utils
             builder.RegisterType<DatabaseUpdate_1_0_0_1_0_1>().As<IDatabaseUpdate>().InstancePerLifetimeScope();
             builder.RegisterType<DatabaseUpdate_1_0_1_1_0_2>().As<IDatabaseUpdate>().InstancePerLifetimeScope();
             builder.RegisterType<DatabaseUpdate_1_0_2_1_0_3>().As<IDatabaseUpdate>().InstancePerLifetimeScope();
+            builder.RegisterType<DatabaseUpdate_1_0_3_1_0_4>().As<IDatabaseUpdate>().InstancePerLifetimeScope();
 
             builder.RegisterType<SqliteDatabaseUpdater>().AsSelf().InstancePerLifetimeScope();
 

--- a/LobotJR/Wolfcoins.cs
+++ b/LobotJR/Wolfcoins.cs
@@ -575,7 +575,7 @@ namespace Wolfcoins
                 var chatters = await twitchClient.GetChatterListAsync();
                 if (chatters != null)
                 {
-                    viewerList = chatters.Where(x => x != null).Select(x => x.UserName).ToList();
+                    viewerList = chatters.Where(x => x != null).Select(x => x.UserLogin).ToList();
                 }
                 else
                 {
@@ -584,7 +584,7 @@ namespace Wolfcoins
                 var moderators = await twitchClient.GetModeratorListAsync();
                 if (moderators != null)
                 {
-                    moderatorList = moderators.Where(x => x != null).Select(x => x.UserName).ToList();
+                    moderatorList = moderators.Where(x => x != null).Select(x => x.UserLogin).ToList();
                 }
                 else
                 {


### PR DESCRIPTION
- Fixed ordination bug in fish list
- Added log file size limit and archive limit
- Added max crashdump limit
- Added logging for systems and modules
- Converted all references to display names to use logins
- Fixed bug causing crash when users with no fish attempt to retrieve personal leaderboard
- Added automatic 401 retry to all non-authentication API calls