### PR TITLE
Feature/award interval fix

### DIFF
--- a/LobotJR/Command/Controller/Player/PlayerController.cs
+++ b/LobotJR/Command/Controller/Player/PlayerController.cs
@@ -413,6 +413,7 @@ namespace LobotJR.Command.Controller.Player
                         }
                     }
                     ExperienceAwarded?.Invoke(xpToAward, coinsToAward, subMultiplier);
+                    LastAward = DateTime.Now;
                 }
             }
         }

--- a/LobotJR/Data/Import/PlayerDataImport.cs
+++ b/LobotJR/Data/Import/PlayerDataImport.cs
@@ -67,8 +67,8 @@ namespace LobotJR.Data.Import
                 { -1, deprived },
                 { 0, deprived },
                 { 1, new CharacterClass("Warrior", true, 0.1f, 0.03f, 0.05f, 0f, 0f) },
-                { 2, new CharacterClass("Mage", true, 0.03f, 0.1f, 0f, 0.05f, 0.05f) },
-                { 3, new CharacterClass("Rogue", true, 0f, 0.05f, 0.1f, 0.03f, 0.03f) },
+                { 2, new CharacterClass("Mage", true, 0.03f, 0.1f, 0f, 0.05f, 0f) },
+                { 3, new CharacterClass("Rogue", true, 0f, 0.05f, 0.1f, 0.03f, 0f) },
                 { 4, new CharacterClass("Ranger", true, 0.05f, 0f, 0.03f, 0.1f, 0f) },
                 { 5, new CharacterClass("Cleric", true, 0.03f, 0.03f, 0.03f, 0.03f, 0.1f) }
             };

--- a/LobotJR/Properties/AssemblyInfo.cs
+++ b/LobotJR/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 
 ## License
 
-This project is licensed under the GPL 3.0 License - see the [LICENSE.md](https://github.com/EmpyrealHell/wolfpack-rpg-client/blob/master/LICENSE.md) file for details
+This project is licensed under the MIT license - see the [LICENSE](https://github.com/EmpyrealHell/wolfpack-rpg-client/blob/master/LICENSE) file for details


### PR DESCRIPTION
- Fixed bug causing xp to be awarded every frame after the first interval elapsed
- Added tests for experience processing to confirm the bug fix
- Fixed bug in the player data import seeding the wrong class stats
- Updated license in readme file to reflect the correct license in the license file