### PR TITLE
Added new flag to ignore whisper commands in chat without a timeout

### DIFF
--- a/LobotJR.Test/Command/CommandManagerTests.cs
+++ b/LobotJR.Test/Command/CommandManagerTests.cs
@@ -264,7 +264,7 @@ namespace LobotJR.Test.Command
         }
 
         [TestMethod]
-        public void ProcessMessageDoesNotAllowWhisperOnlyMessageInPublicChat()
+        public void ProcessMessageDoesNotAllowWhisperOnlyTimeoutMessageInPublicChat()
         {
             var user = UserController.GetUserByName("Auth");
             var result = CommandManager.ProcessMessage("Foo", user, false);
@@ -282,6 +282,18 @@ namespace LobotJR.Test.Command
             Assert.IsTrue(result.Processed);
             Assert.IsFalse(result.Errors.Any());
             Assert.AreEqual(1, CommandViewMock.PublicCount);
+        }
+
+        [TestMethod]
+        public void ProcessMessageIgnoresWhisperOnlyNonTimeoutMessageInPublicChat()
+        {
+            var user = UserController.GetUserByName("Auth");
+            var result = CommandManager.ProcessMessage("Ignore", user, false);
+            Assert.IsTrue(result.Processed);
+            Assert.IsFalse(result.Errors.Any());
+            Assert.IsFalse(result.Responses.Any());
+            Assert.IsFalse(result.Messages.Any());
+            Assert.AreEqual(0, CommandViewMock.IgnoreCount);
         }
     }
 }

--- a/LobotJR.Test/Mocks/MockCommandView.cs
+++ b/LobotJR.Test/Mocks/MockCommandView.cs
@@ -17,6 +17,7 @@ namespace LobotJR.Test.Mocks
         public int FooCount { get; private set; } = 0;
         public int FooCountCompact { get; private set; } = 0;
         public int PublicCount { get; private set; } = 0;
+        public int IgnoreCount { get; private set; } = 0;
         public int ModFooCount { get; private set; } = 0;
         public int SubFooCount { get; private set; } = 0;
         public int VipFooCount { get; private set; } = 0;
@@ -30,7 +31,7 @@ namespace LobotJR.Test.Mocks
         public int UserParamCount { get; private set; } = 0;
         public int UserAndStringParamCount { get; private set; } = 0;
         public int NoParseCount { get; private set; } = 0;
-        public int TotalCount { get { return FooCount + FooCountCompact + PublicCount + ModFooCount + SubFooCount + VipFooCount + AdminFooCount + SingleParamCount + MultiParamCount + IntParamCount + BoolParamCount + OptionalParamCount + UserAndOptionalParamCount + UserParamCount + UserAndStringParamCount + NoParseCount; } }
+        public int TotalCount { get { return FooCount + FooCountCompact + PublicCount + IgnoreCount + ModFooCount + SubFooCount + VipFooCount + AdminFooCount + SingleParamCount + MultiParamCount + IntParamCount + BoolParamCount + OptionalParamCount + UserAndOptionalParamCount + UserParamCount + UserAndStringParamCount + NoParseCount; } }
 
         public MockCommandView()
         {
@@ -39,6 +40,7 @@ namespace LobotJR.Test.Mocks
                 new CommandHandler("Foo", this, CommandMethod.GetInfo(Foo), CommandMethod.GetInfo<string>(FooCompact), "Foo"),
                 new CommandHandler("Unrestricted", this, CommandMethod.GetInfo(Foo), CommandMethod.GetInfo<string>(FooCompact), "Unrestricted"),
                 new CommandHandler("Public", this, CommandMethod.GetInfo(Public), "Public") { WhisperOnly = false },
+                new CommandHandler("Ignore", this, CommandMethod.GetInfo(Public), "Ignore") { TimeoutInChat = false },
                 new CommandHandler("ModFoo", this, CommandMethod.GetInfo(ModFoo), "ModFoo"),
                 new CommandHandler("SubFoo", this, CommandMethod.GetInfo(SubFoo), "SubFoo"),
                 new CommandHandler("VipFoo", this, CommandMethod.GetInfo(VipFoo), "VipFoo"),
@@ -57,7 +59,7 @@ namespace LobotJR.Test.Mocks
 
         public void ResetCounts()
         {
-            FooCount = FooCountCompact = PublicCount = ModFooCount = SubFooCount = VipFooCount = AdminFooCount = SingleParamCount
+            FooCount = FooCountCompact = PublicCount = IgnoreCount = ModFooCount = SubFooCount = VipFooCount = AdminFooCount = SingleParamCount
                 = MultiParamCount = IntParamCount = BoolParamCount = OptionalParamCount = UserAndStringParamCount = UserParamCount
                 = UserAndStringParamCount = NoParseCount = 0;
         }
@@ -69,6 +71,12 @@ namespace LobotJR.Test.Mocks
         }
 
         public CommandResult Public()
+        {
+            PublicCount++;
+            return new CommandResult(true);
+        }
+
+        public CommandResult Ignore()
         {
             PublicCount++;
             return new CommandResult(true);

--- a/LobotJR/Command/CommandHandler.cs
+++ b/LobotJR/Command/CommandHandler.cs
@@ -22,6 +22,13 @@ namespace LobotJR.Command
         public bool WhisperOnly { get; set; } = true;
 
         /// <summary>
+        /// Determines whether users executing this command in chat will be
+        /// timed out if they try to execute this command in chat instead of a
+        /// whisper. This will only trigger if WhisperOnly is set to true.
+        /// </summary>
+        public bool TimeoutInChat { get; set; } = true;
+
+        /// <summary>
         /// The strings that can be used to issue the command.
         /// </summary>
         public IEnumerable<string> CommandStrings { get; }

--- a/LobotJR/Command/View/Dungeons/DungeonView.cs
+++ b/LobotJR/Command/View/Dungeons/DungeonView.cs
@@ -159,7 +159,7 @@ namespace LobotJR.Command.View.Dungeons
                 var leader = UserController.GetUserById(party.Leader);
                 PushNotification?.Invoke(user, new CommandResult($"You declined {leader.Username}'s invite."));
                 PushNotification?.Invoke(leader, new CommandResult($"{user.Username} has declined your party invite."));
-                Logger.Info("{user} delcined party invite from {leader}.", user.Username, leader.Username);
+                Logger.Info("{user} declined party invite from {leader}.", user.Username, leader.Username);
             }
         }
 

--- a/LobotJR/Command/View/General/ConfirmationView.cs
+++ b/LobotJR/Command/View/General/ConfirmationView.cs
@@ -27,8 +27,8 @@ namespace LobotJR.Command.View.General
             ConfirmationController = confirmationController;
             Commands = new List<CommandHandler>()
             {
-                new CommandHandler("Confirm", this, CommandMethod.GetInfo(Confirm), "y", "yes", "accept", "confirm"),
-                new CommandHandler("Cancel", this, CommandMethod.GetInfo(Cancel), "n", "no", "decline", "cancel", "nevermind"),
+                new CommandHandler("Confirm", this, CommandMethod.GetInfo(Confirm), "y", "yes", "accept", "confirm") { TimeoutInChat = false },
+                new CommandHandler("Cancel", this, CommandMethod.GetInfo(Cancel), "n", "no", "decline", "cancel", "nevermind") { TimeoutInChat = false },
             };
         }
 


### PR DESCRIPTION
- Added a flag to ignore whisper-only commands in chat, which prevents them from being processed, but does not trigger a timeout
- Set new flag for confirm and cancel commands