### PR TITLE
Feature/last formed fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Wolfpack RPG Client Contribution Guidelines
+# Lobot Contribution Guidelines
 
 ## Introduction
 
 ### Welcome
 
-If you're reading this, then you're thinking about making a contribution to the Wolfpack RPG server. Thanks! This app is built and maintained by volunteers who want to support LobosJr and the community he has built. We wouldn't have this app without people like you.
+If you're reading this, then you're thinking about making a contribution to Lobot, the Wolfpack RPG server. Thanks! This app is built and maintained by volunteers who want to support LobosJr and the community he has built. We wouldn't have this app without people like you.
 
 This document contains a set of guidelines that will help you make sure that any work you do can be integrated into the application seamlessly. We know your time is valuable, and the last thing we want to do is annoy our potential contributors so much that they don't come back. Nobody wants to have to go back and forth for days on a PR.
 
@@ -133,8 +133,8 @@ If you're making large changes to a class, like reorganizing things or moving pa
 
 When creating a bug report, copy the template below and fill it out in your bug description. If there is additional information, add it below the filled-out form. You can also attach screenshots or other helpful information if necessary.
 
-    I encountered this bug on app version {version number}
-    This was encountered on the main [github pages site](https://empyrealhell.github.io/wolfpack-rpg-client)
+    I encountered this bug on at {date and time}
+    The Twitch username I encountered the issue on is {Twitch username}
 
     What I was doing:
     {Description of the action you were attempting}
@@ -177,6 +177,6 @@ The [LobosJr Discord server](http://discord.gg/wolfpack) is another area where t
 
 ### Development Community
 
-The preferred contact method for each of the application managers is listed in [the readme](https://github.com/EmpyrealHell/wolfpack-rpg-client/blob/master/README.md). This is the fastest way to get ahold of someone about the application.
+The preferred contact method for each of the application managers is listed in [the readme](https://github.com/lobosjrgaming/lobotjr/blob/master/README.md). This is the fastest way to get ahold of someone about the application.
 
 Due to the small size of the team, there isn't a channel in the Discord server at this time.

--- a/LobotJR.Test/Controllers/Fishing/FishingControllerTests.cs
+++ b/LobotJR.Test/Controllers/Fishing/FishingControllerTests.cs
@@ -69,6 +69,12 @@ namespace LobotJR.Test.Controllers.Fishing
             Assert.IsTrue(fish.MaximumLength >= catchData.Length);
         }
 
+        /// <summary>
+        /// This test evaluates one of the randomization methods to check if
+        /// the distribution matches expectations. Because this is a random
+        /// process the test can fail without indicating an actual issue, but
+        /// it should pass *most* of the time.
+        /// </summary>
         [TestMethod]
         public void CalculateFishSizesRandomizesWithSteppedWeights()
         {
@@ -95,6 +101,12 @@ namespace LobotJR.Test.Controllers.Fishing
             Assert.IsTrue(maxGroupSize > 0 && maxGroupSize < sampleSize * 0.02);
         }
 
+        /// <summary>
+        /// This test evaluates one of the randomization methods to check if
+        /// the distribution matches expectations. Because this is a random
+        /// process the test can fail without indicating an actual issue, but
+        /// it should pass *most* of the time.
+        /// </summary>
         [TestMethod]
         public void CalculateFishSizesRandomizesWithNormalDistribution()
         {

--- a/LobotJR/Command/Controller/Dungeons/GroupFinderController.cs
+++ b/LobotJR/Command/Controller/Dungeons/GroupFinderController.cs
@@ -22,7 +22,7 @@ namespace LobotJR.Command.Controller.Dungeons
         private readonly PartyController PartyController;
         private readonly List<QueueEntry> GroupFinderQueue = new List<QueueEntry>();
 
-        public DateTime LastGroupFormed { get; private set; } = DateTime.MinValue;
+        public DateTime? LastGroupFormed { get; private set; } = null;
 
         /// <summary>
         /// Event handler for events related to the dungeon finder queue.
@@ -194,6 +194,7 @@ namespace LobotJR.Command.Controller.Dungeons
             GroupFinderQueue.Add(new QueueEntry(player, dungeons.ToList()));
             if (TryCreateParty(out var party))
             {
+                LastGroupFormed = DateTime.Now;
                 PartyFound?.Invoke(party);
                 return true;
             }

--- a/LobotJR/Command/View/Dungeons/GroupFinderView.cs
+++ b/LobotJR/Command/View/Dungeons/GroupFinderView.cs
@@ -134,9 +134,14 @@ namespace LobotJR.Command.View.Dungeons
             var entry = GroupFinderController.GetPlayerQueueEntry(player);
             if (entry != null)
             {
+                var lastFormed = "No groups have been formed recently.";
+                if (GroupFinderController.LastGroupFormed != null)
+                {
+                    lastFormed = $"The last group was formed {(DateTime.Now - GroupFinderController.LastGroupFormed.Value).ToReadableTime()} ago.";
+                }
                 return new CommandResult(
                     $"You are queued for {entry.Dungeons.Count()} dungeons and have been waiting {(DateTime.Now - entry.QueueTime).ToReadableTime()}.",
-                    $"The last group was formed {(DateTime.Now - GroupFinderController.LastGroupFormed).ToReadableTime()} ago.");
+                    lastFormed);
             }
             return new CommandResult("You are not queued in the Group Finder.");
         }

--- a/LobotJR/Properties/AssemblyInfo.cs
+++ b/LobotJR/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.7.0")]
-[assembly: AssemblyFileVersion("1.1.7.0")]
+[assembly: AssemblyVersion("1.1.8.0")]
+[assembly: AssemblyFileVersion("1.1.8.0")]


### PR DESCRIPTION
- Fixed a bug causing the last group formation value to not be set when a group is formed
- Modified the !queuetime command to respond in a more reasonable way when no group has been formed.
- Updated the contributing.md file to update values referencing the project the template was copied from.