### PR TITLE
feature/groupfinder-class-fix

### DIFF
--- a/LobotJR.Test/Controllers/Dungeons/DungeonControllerTests.cs
+++ b/LobotJR.Test/Controllers/Dungeons/DungeonControllerTests.cs
@@ -528,7 +528,7 @@ namespace LobotJR.Test.Controllers.Dungeons
             {
                 var xp = (int)Math.Round(11 + (member.Level - 2) * 3f);
                 var coins = (int)Math.Round(50 * (1 + 0.05f * member.Level));
-                listener.Verify(x => x(member, xp, coins, It.IsNotNull<Item>(), false), Times.Once);
+                listener.Verify(x => x(member, xp, coins, It.IsNotNull<Item>(), false, false, false), Times.Once);
                 if (!member.Equals(party.Members.First()))
                 {
                     petListener.Verify(x => x(It.Is<User>(y => y.TwitchId.Equals(member.UserId)), It.IsNotNull<Stable>()));
@@ -555,7 +555,7 @@ namespace LobotJR.Test.Controllers.Dungeons
             {
                 var xp = (int)Math.Round(11 + (member.Level - 2) * 3f);
                 var coins = (int)Math.Round(50 * (1 + 0.05f * member.Level));
-                listener.Verify(x => x(member, xp, coins, null, false), Times.Once);
+                listener.Verify(x => x(member, xp, coins, null, false, false, false), Times.Once);
                 Assert.AreEqual(baseXp[member.UserId] + xp, member.Experience);
                 Assert.AreEqual(baseCoins[member.UserId] + coins, member.Currency);
             }
@@ -579,7 +579,7 @@ namespace LobotJR.Test.Controllers.Dungeons
             {
                 var xp = (int)Math.Round((11 + (member.Level - 2) * 3f) * (1 + settings.DungeonCritBonus));
                 var coins = (int)Math.Round(50 * (1 + 0.05f * member.Level));
-                listener.Verify(x => x(member, xp, coins, null, false), Times.Once);
+                listener.Verify(x => x(member, xp, coins, null, false, false, true), Times.Once);
             }
             Assert.AreEqual(PartyState.Full, party.State);
             Assert.AreEqual(0, party.CurrentEncounter);
@@ -603,7 +603,7 @@ namespace LobotJR.Test.Controllers.Dungeons
             {
                 var xp = (int)Math.Round(11 + (member.Level - 2) * 3f) * 2;
                 var coins = (int)Math.Round(50 * (1 + 0.05f * member.Level)) * 2;
-                listener.Verify(x => x(member, xp, coins, null, true), Times.Once);
+                listener.Verify(x => x(member, xp, coins, null, true, true, false), Times.Once);
                 Assert.IsTrue(db.DungeonLockouts.Read(x => x.UserId.Equals(member.UserId)).Any());
             }
             Assert.AreEqual(PartyState.Disbanded, party.State);
@@ -638,7 +638,7 @@ namespace LobotJR.Test.Controllers.Dungeons
             {
                 var xp = (int)Math.Round(11 + (member.Level - 2) * 3f);
                 var coins = (int)Math.Round(50 * (1 + 0.05f * member.Level));
-                listener.Verify(x => x(member, xp, coins, null, false), Times.Once);
+                listener.Verify(x => x(member, xp, coins, null, true, false, false), Times.Once);
             }
             Assert.AreEqual(PartyState.Disbanded, party.State);
             Assert.AreEqual(0, party.CurrentEncounter);
@@ -672,7 +672,7 @@ namespace LobotJR.Test.Controllers.Dungeons
             {
                 var xp = (int)Math.Round(11 + (member.Level - 2) * 3f);
                 var coins = (int)Math.Round(50 * (1 + 0.05f * member.Level));
-                listener.Verify(x => x(member, xp, coins, null, false), Times.Once);
+                listener.Verify(x => x(member, xp, coins, null, false, false, false), Times.Once);
             }
             Assert.AreEqual(PartyState.Full, party.State);
             Assert.AreEqual(0, party.CurrentEncounter);

--- a/LobotJR.Test/Controllers/Dungeons/GroupFinderControllerTests.cs
+++ b/LobotJR.Test/Controllers/Dungeons/GroupFinderControllerTests.cs
@@ -183,7 +183,8 @@ namespace LobotJR.Test.Controllers.Dungeons
             var player = db.PlayerCharacters.Read().First();
             var player2 = db.PlayerCharacters.Read().ElementAt(2);
             var player3 = db.PlayerCharacters.Read().ElementAt(3);
-            player3.CharacterClass = db.CharacterClassData.Read(x => x.CanPlay && !x.Equals(player.CharacterClass)).First();
+            player2.CharacterClass = db.CharacterClassData.Read(x => x.CanPlay && !x.Equals(player.CharacterClass)).First();
+            player3.CharacterClass = db.CharacterClassData.Read(x => x.CanPlay && !x.Equals(player.CharacterClass) && !x.Equals(player2.CharacterClass)).First();
             var run = new DungeonRun(db.DungeonData.Read().First(), db.DungeonModeData.Read().First());
             var listener = new Mock<GroupFinderController.DungeonQueueHandler>();
             Controller.PartyFound += listener.Object;
@@ -211,7 +212,8 @@ namespace LobotJR.Test.Controllers.Dungeons
             var player = db.PlayerCharacters.Read().First();
             var player2 = db.PlayerCharacters.Read().ElementAt(2);
             var player3 = db.PlayerCharacters.Read().ElementAt(3);
-            player3.CharacterClass = db.CharacterClassData.Read(x => x.CanPlay && !x.Equals(player.CharacterClass)).First();
+            player2.CharacterClass = db.CharacterClassData.Read(x => x.CanPlay && !x.Equals(player.CharacterClass)).First();
+            player3.CharacterClass = db.CharacterClassData.Read(x => x.CanPlay && !x.Equals(player.CharacterClass) && !x.Equals(player2.CharacterClass)).First();
             var run = new DungeonRun(db.DungeonData.Read().First(), db.DungeonModeData.Read().First());
             var listener = new Mock<GroupFinderController.DungeonQueueHandler>();
             Controller.PartyFound += listener.Object;
@@ -230,7 +232,9 @@ namespace LobotJR.Test.Controllers.Dungeons
             var player2 = db.PlayerCharacters.Read().ElementAt(2);
             var player3 = db.PlayerCharacters.Read().ElementAt(3);
             var player4 = db.PlayerCharacters.Read().ElementAt(4);
-            player4.CharacterClass = db.CharacterClassData.Read(x => x.CanPlay && !x.Equals(player.CharacterClass)).First();
+            player2.CharacterClass = db.CharacterClassData.Read(x => x.CanPlay && !x.Equals(player.CharacterClass)).First();
+            player3.CharacterClass = player2.CharacterClass;
+            player4.CharacterClass = db.CharacterClassData.Read(x => x.CanPlay && !x.Equals(player.CharacterClass) && !x.Equals(player2.CharacterClass)).First();
             var run = new DungeonRun(db.DungeonData.Read().First(), db.DungeonModeData.Read().First());
             var listener = new Mock<GroupFinderController.DungeonQueueHandler>();
             Controller.PartyFound += listener.Object;

--- a/LobotJR.Test/Mocks/MockConnectionManager.cs
+++ b/LobotJR.Test/Mocks/MockConnectionManager.cs
@@ -194,6 +194,7 @@ namespace LobotJR.Test.Mocks
             context.CharacterClassData.Create(new CharacterClass() { CanPlay = false, Name = "NonPlayable" });
             context.CharacterClassData.Create(new CharacterClass() { CanPlay = true, Name = "Playable" });
             context.CharacterClassData.Create(new CharacterClass() { CanPlay = true, Name = "PlayableAlternate" });
+            context.CharacterClassData.Create(new CharacterClass() { CanPlay = true, Name = "PlayableThird" });
         }
 
         private void InitializePlayers(IDatabase context)

--- a/LobotJR/Command/Controller/Dungeons/GroupFinderController.cs
+++ b/LobotJR/Command/Controller/Dungeons/GroupFinderController.cs
@@ -46,7 +46,7 @@ namespace LobotJR.Command.Controller.Dungeons
         private bool IsViableParty(IEnumerable<QueueEntry> players)
         {
             var distribution = players.Select(x => x.UserId).GroupBy(x => PlayerController.GetPlayerByUserId(x).CharacterClass);
-            return !distribution.Any(x => x.Count() > 2);
+            return !distribution.Any(x => x.Count() > 1);
         }
 
         private IEnumerable<DungeonRun> GetGroupDungeons(IEnumerable<QueueEntry> players)

--- a/LobotJR/Command/View/Dungeons/DungeonView.cs
+++ b/LobotJR/Command/View/Dungeons/DungeonView.cs
@@ -84,11 +84,11 @@ namespace LobotJR.Command.View.Dungeons
             };
         }
 
-        private void DungeonController_DungeonComplete(PlayerCharacter player, int experience, int currency, Item loot, bool groupFinderBonus)
+        private void DungeonController_DungeonComplete(PlayerCharacter player, int experience, int currency, Item loot, bool wasQueueGroup, bool groupFinderBonus, bool critBonus)
         {
             var user = PlayerController.GetUserByPlayer(player);
             var messages = new List<string>();
-            if (!groupFinderBonus)
+            if (!wasQueueGroup)
             {
                 messages.Add("Dungeon complete. Your party remains intact.");
             }
@@ -96,12 +96,18 @@ namespace LobotJR.Command.View.Dungeons
             {
                 messages.Add("You earned double rewards for completing a daily Group Finder dungeon! Queue up again in 24 hours to receive the 2x bonus again! (You can whisper me '!daily' for a status.)");
             }
+            if (critBonus)
+            {
+                var settings = SettingsManager.GetGameSettings();
+                var percentBonus = (int)Math.Round(settings.DungeonCritBonus * 100);
+                messages.Add($"It was a critical success! You earned a {percentBonus}% bonus to experience!");
+            }
             messages.Add($"{user.Username}, you've earned {experience} XP and {currency} Wolfcoins for completing the dungeon!");
             if (loot != null)
             {
                 messages.Add($"You looted {loot.Name}!");
             }
-            if (groupFinderBonus)
+            if (wasQueueGroup)
             {
                 messages.Add("You completed a group finder dungeon. Type !queue to join another group!");
             }

--- a/LobotJR/Properties/AssemblyInfo.cs
+++ b/LobotJR/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.8.0")]
-[assembly: AssemblyFileVersion("1.1.8.0")]
+[assembly: AssemblyVersion("1.1.9.0")]
+[assembly: AssemblyFileVersion("1.1.9.0")]


### PR DESCRIPTION
- Changed group finder to have max 1 of each class in group.
- Added message when earning critical xp.
- Fixed bug causing the wrong end message to play when in the second group finder group of the day