### PR TITLE
Feature/pet notification fix

### DIFF
--- a/LobotJR/Bot.cs
+++ b/LobotJR/Bot.cs
@@ -186,7 +186,7 @@ namespace LobotJR
                             continue;
                         }
                     }
-                    else if (message.IsChat)
+                    else if (message.IsChat && !message.IsShared)
                     {
                         userController.UpdateUser(chatter, message);
                         var triggerResult = triggerManager.ProcessTrigger(message.Message, chatter);

--- a/LobotJR/Command/Controller/Dungeons/DungeonController.cs
+++ b/LobotJR/Command/Controller/Dungeons/DungeonController.cs
@@ -321,7 +321,7 @@ namespace LobotJR.Command.Controller.Dungeons
 
         private float PartySuccessChance(IEnumerable<PlayerCharacter> players, Dictionary<CharacterClass, float> classMultipliers)
         {
-            return players.Sum(x => PlayerSuccessChance(x) * classMultipliers[x.CharacterClass]);
+            return players.Sum(x => PlayerSuccessChance(x) * classMultipliers[x.CharacterClass]) * (players.Count() / SettingsManager.GetGameSettings().DungeonPartySize);
         }
 
         private float PlayerDeathChance(PlayerCharacter player)

--- a/LobotJR/Command/View/Gloat/GloatView.cs
+++ b/LobotJR/Command/View/Gloat/GloatView.cs
@@ -31,7 +31,7 @@ namespace LobotJR.Command.View.Gloat
             "A fearsome champion of the Wolfpack!",
             "A vicious pack leader!",
             "A famed Wolfpack Captain!",
-            "A brutal commandef of the Wolfpack!",
+            "A brutal commander of the Wolfpack!",
             "Decorated Chieftain of the Wolfpack!",
             "A WarChieftain of the Wolfpack!",
             "A sacred Wolfpack Justicar",

--- a/LobotJR/Command/View/Pets/PetView.cs
+++ b/LobotJR/Command/View/Pets/PetView.cs
@@ -84,7 +84,8 @@ namespace LobotJR.Command.View.Pets
         private void PetController_PetFound(User user, Stable stable)
         {
             var result = new CommandResult(user);
-            var userStable = PetController.GetStableForUser(user);
+            var userStable = PetController.GetStableForUser(user).ToList();
+            userStable.Add(stable);
             string responseString;
             string messageString;
             var petName = GetPetName(stable);

--- a/LobotJR/Command/View/Pets/PetView.cs
+++ b/LobotJR/Command/View/Pets/PetView.cs
@@ -110,7 +110,10 @@ namespace LobotJR.Command.View.Pets
                 responseString += " WOW! And it's a sparkly version! Lucky you!";
             }
             result.Responses.Add(responseString);
-            if (userStable.Count() == PetController.GetPets().Count())
+            var allPets = PetController.GetPets().Select(x => x.Id).Distinct();
+            var normalPets = userStable.Where(x => !x.IsSparkly).Select(x => x.Id).Distinct();
+            var sparklyPets = userStable.Where(x => x.IsSparkly).Select(x => x.Id).Distinct();
+            if (!allPets.Except(normalPets).Any() && !allPets.Except(sparklyPets).Any())
             {
                 result.Responses.Add("You've collected all of the available pets! Congratulations!");
             }

--- a/LobotJR/Interface/Main.xaml.cs
+++ b/LobotJR/Interface/Main.xaml.cs
@@ -618,7 +618,7 @@ namespace LobotJR.Interface
             };
             dialog.Left = Left + Width / 2 - dialog.Width / 2;
             dialog.Top = Top + Height / 2 - dialog.Height / 2;
-            var result = dialog.ShowDialog();
+            dialog.ShowDialog();
         }
 
         private async void AccessButton_Click(object sender, RoutedEventArgs e)

--- a/LobotJR/Properties/AssemblyInfo.cs
+++ b/LobotJR/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.2.0")]
-[assembly: AssemblyFileVersion("1.2.2.0")]
+[assembly: AssemblyVersion("1.2.3.0")]
+[assembly: AssemblyFileVersion("1.2.3.0")]

--- a/LobotJR/Twitch/Model/IrcMessage.cs
+++ b/LobotJR/Twitch/Model/IrcMessage.cs
@@ -72,6 +72,11 @@ namespace LobotJR.Twitch.Model
         /// going through Twitch.
         /// </summary>
         public bool IsInternal { get { if (Tags.TryGetValue("internal", out var value)) { return value.Equals(InternalMessageId); } return false; } }
+        /// <summary>
+        /// Indicates whether the message was sent on the local chat channel,
+        /// or if it came across as part of a shared chat channel.
+        /// </summary>
+        public bool IsShared { get; private set; }
 
         public static IrcMessage Parse(string message)
         {
@@ -89,6 +94,10 @@ namespace LobotJR.Twitch.Model
                 output.Tags.TryGetValue("user-id", out string id);
                 output.UserId = id;
                 output.UserName = output.Tags.ContainsKey("display-name") ? output.Tags["display-name"] : content.Groups["user"].Value;
+                if (output.Tags.ContainsKey("source-room-id") && output.Tags.ContainsKey("room-id"))
+                {
+                    output.IsShared = !output.Tags["source-room-id"].Equals(output.Tags["room-id"]);
+                }
                 output.Command = content.Groups["command"].Value;
                 output.Channel = content.Groups["channel"].Value;
                 output.Message = content.Groups["message"].Value;


### PR DESCRIPTION
- Fixed a bug causing pet notification messages to be sent at the wrong times.
- Fixed a bug causing dungeons to be easier than intended when adventuring without a full party.
- Changed triggers to only fire on messages that originated in the stream channel when using merged chat.